### PR TITLE
Refactor type imports to new directory structure

### DIFF
--- a/src/DataTable.tsx
+++ b/src/DataTable.tsx
@@ -1,5 +1,5 @@
 // types
-import type { DataTableProps } from './@types/datatable-props'
+import type { DataTableProps } from './types/data-table-props'
 // vendors
 import { DndProvider } from 'react-dnd'
 import { HTML5Backend } from 'react-dnd-html5-backend'

--- a/src/components/table-toolbar.functions.create-csv-download.ts
+++ b/src/components/table-toolbar.functions.create-csv-download.ts
@@ -1,6 +1,6 @@
 import type { MUIDataTableColumnState } from 'mui-datatables'
-import type { DataTableData } from '../@types/datatable-props'
-import type { DataTableOptions } from '../@types/data-table-options'
+import type { DataTableData } from '../types/data-table-props'
+import type { DataTableOptions } from '../types/data-table-options'
 
 type DataType = { index: number; data: DataTableData[0] }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,8 @@ export type {
     DataTableProps,
     DataTableColumns,
     DataTableData
-} from './@types/datatable-props'
-export type { DataTableOptions } from './@types/data-table-options'
+} from './types/data-table-props'
+export type { DataTableOptions } from './types/data-table-options'
 
 // export { default as Popover } from './components/Popover'
 // export { default as TableBodyCell } from './components/TableBodyCell'

--- a/src/types/data-table-components.ts
+++ b/src/types/data-table-components.ts
@@ -1,0 +1,37 @@
+import type {
+    MUIDataTableBody,
+    MUIDataTableCheckboxProps,
+    MUIDataTableExpandButton,
+    MUIDataTableFilterList,
+    MUIDataTableFooter,
+    MUIDataTableHead,
+    MUIDataTableResize,
+    MUIDataTableToolbar,
+    MUIDataTableToolbarSelect,
+    MUIDataTableViewCol
+} from 'mui-datatables'
+import type { ReactNode } from 'react'
+import type { SvgIconComponent } from '@mui/icons-material'
+
+export type DataTableComponents = Partial<{
+    Checkbox: ((props: MUIDataTableCheckboxProps) => ReactNode) | ReactNode
+    ExpandButton: ((props: MUIDataTableExpandButton) => ReactNode) | ReactNode
+    TableBody: ((props: MUIDataTableBody) => ReactNode) | ReactNode
+    TableViewCol: ((props: MUIDataTableViewCol) => ReactNode) | ReactNode
+    TableFilterList: ((props: MUIDataTableFilterList) => ReactNode) | ReactNode
+    TableFooter: ((props: MUIDataTableFooter) => ReactNode) | ReactNode
+    TableHead: ((props: MUIDataTableHead) => ReactNode) | ReactNode
+    TableResize: ((props: MUIDataTableResize) => ReactNode) | ReactNode
+    TableToolbar: ((props: MUIDataTableToolbar) => ReactNode) | ReactNode
+    TableToolbarSelect:
+        | ((props: MUIDataTableToolbarSelect) => ReactNode)
+        | ReactNode
+    Tooltip: ReactNode
+    icons: Partial<{
+        SearchIcon: SvgIconComponent | ReactNode
+        DownloadIcon: SvgIconComponent | ReactNode
+        PrintIcon: SvgIconComponent | ReactNode
+        ViewColumnIcon: SvgIconComponent | ReactNode
+        FilterIcon: SvgIconComponent | ReactNode
+    }>
+}>

--- a/src/types/data-table-options.ts
+++ b/src/types/data-table-options.ts
@@ -1,5 +1,5 @@
 import type { MUIDataTableOptions } from 'mui-datatables'
-import type { DataTableData } from './datatable-props'
+import type { DataTableData } from './data-table-props'
 
 type DataType = {
     index: number

--- a/src/types/data-table-props.ts
+++ b/src/types/data-table-props.ts
@@ -1,8 +1,9 @@
-import type { MUIDataTableProps, MUIDataTableState } from 'mui-datatables'
+import type { MUIDataTableState } from 'mui-datatables'
 import type { Component, ReactNode, RefObject } from 'react'
 import type { DataTableOptions } from './data-table-options'
 import type { MUIDataTableColumn as DataTableColumn } from 'mui-datatables'
-// import type { SxProps } from '@mui/material'
+import type { DataTableComponents } from './data-table-components'
+import type { SxProps } from '@mui/material'
 
 export type DataTableColumns = (string | DataTableColumn)[]
 export type DataTableData = (number | string | null | undefined)[][]
@@ -10,7 +11,7 @@ export type DataTableData = (number | string | null | undefined)[][]
 export interface DataTableProps {
     columns: DataTableColumns
 
-    components?: MUIDataTableProps['components']
+    components?: DataTableComponents
 
     data: DataTableData
 
@@ -25,6 +26,11 @@ export interface DataTableProps {
           >
         | undefined
 
-    /** Override `<DataTable />` Style */
-    // sx?: SxProps
+    /**
+     * Override `<DataTable />` Style
+     *
+     * @todo WILL IMPLEMENT THIS LATER
+     * @experimental not implemented yet
+     */
+    sx?: SxProps
 }


### PR DESCRIPTION
Move type definitions from the `@types` directory to a new `types` directory and update all related imports accordingly. This change improves organization and clarity of type definitions.