### PR TITLE
Add documentation for resizable columns and adjust font size

### DIFF
--- a/docs/app/(main)/docs/_mds/features/resizable-columns.mdx
+++ b/docs/app/(main)/docs/_mds/features/resizable-columns.mdx
@@ -1,0 +1,46 @@
+# Resizable Columns
+
+The **DataTable** component supports a convenient feature called **Resizable Columns**, allowing users to adjust the width of table columns according to their needs. This provides a flexible and user-friendly way to display data, especially when working with varying screen sizes or datasets.
+
+#### How It Works
+
+When **Resizable Columns** is enabled, each column in the table can be resized by clicking and dragging the column edges. This gives users control over how much space each column occupies, improving data visibility and usability.
+
+#### Enabling Resizable Columns
+
+To enable resizable columns, set the `resizableColumns` property to `true` in the `options` prop of the **DataTable** component.
+
+#### Example Usage
+
+```jsx
+import React from 'react'
+import DataTable from './DataTable'
+
+const MyComponent = () => {
+    const options = {
+        resizableColumns: true // Enable resizable columns
+    }
+
+    return <DataTable data={myData} columns={myColumns} options={options} />
+}
+
+export default MyComponent
+```
+
+#### Explanation
+
+- **`resizableColumns` (boolean)**:
+    - Set to `true` to allow users to resize columns by dragging the edges.
+    - Defaults to `false` if not specified, meaning columns will have a fixed width.
+
+#### Benefits
+
+- **Improved Usability**: Users can adjust column widths to focus on the most relevant data.
+- **Customization**: Supports different screen sizes and user preferences.
+- **Dynamic Layouts**: Makes the table adaptable for various use cases, from detailed reports to compact summaries.
+
+#### Try It Out
+
+> **Live Demo**: [Check out an example of resizable columns in action](/examples/resizable-columns)
+
+With the **Resizable Columns** feature, your **DataTable** becomes more flexible and user-friendly, making it an essential tool for displaying data interactively.

--- a/docs/app/(main)/docs/_route--enum.tsx
+++ b/docs/app/(main)/docs/_route--enum.tsx
@@ -7,6 +7,7 @@ export enum Route {
     FEATURES__DEBOUNCE_SEARCH = 'features/debounce-search',
     FEATURES__LOCALIZATION = 'features/localization',
     FEATURES__REMOTE_DATA = 'features/remote-data',
+    FEATURES__RESIZABLE_COLUMNS = 'features/resizable-columns',
 
     API = 'api',
     API__DATATABLE = 'api/datatable'

--- a/docs/components/code-snippet.tsx
+++ b/docs/components/code-snippet.tsx
@@ -32,8 +32,9 @@ export function CodeSnippet({
                     sx={{
                         maxWidth: '100%',
                         overflow: 'auto',
-                        px: 3,
-                        py: 2.5,
+                        fontSize: '0.95rem',
+                        p: 2.5,
+                        pt: 2,
                         m: 0
                     }}
                 >

--- a/src/data-table.props.type/options.ts
+++ b/src/data-table.props.type/options.ts
@@ -441,7 +441,13 @@ export interface DataTableOptions {
         rowMeta: { dataIndex: number; rowIndex: number }
     ) => ReactNode
 
-    /** Enable/disable resizable columns. */
+    /**
+     * Set to `true` to allow users to resize columns by dragging the edges.
+     *
+     * @see https://mui-datatable-delight.vercel.app/docs/features/resizable-columns
+     *
+     * @default false
+     */
     resizableColumns?: boolean
 
     /**


### PR DESCRIPTION
Introduce a new documentation page for the resizable columns feature in the DataTable component, enhancing user guidance. Adjust the font size in the code snippet component for better readability.