### PR TITLE
Remove `TEXT_LABELS` and enhance Jest configuration for Next.js

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,33 +1,21 @@
 import type { Config } from 'jest'
-import type { TsJestTransformerOptions } from 'ts-jest'
+import nextJest from 'next/jest.js'
 
-export default {
-    collectCoverage: true,
-    collectCoverageFrom: [
-        'src/**/*.{ts,tsx}',
-        '!src/**/*.d.ts',
-        '!**/vendor/**'
-    ],
-    coverageDirectory: 'coverage',
-    testEnvironment: 'jsdom',
-    transform: {
-        '.(ts|tsx)': [
-            'ts-jest',
-            {
-                /**
-                 * @todo REMOVE THIS OPTION WHEN ALL FILES ARE TYPES SAFE
-                 */
-                diagnostics: false
-            } satisfies TsJestTransformerOptions
-        ]
-    },
-    coveragePathIgnorePatterns: [
-        '/node_modules/',
-        '/coverage',
-        'package.json',
-        'package-lock.json',
-        'reportWebVitals.ts',
-        'setupTests.ts',
-        'index.tsx'
-    ]
-} satisfies Config
+/**
+ * @see https://nextjs.org/docs/app/building-your-application/testing/jest
+ */
+const createJestConfig = nextJest({
+    // Provide the path to your Next.js app to load next.config.js and .env files in your test environment
+    // dir: './'
+})
+
+// Add any custom config to be passed to Jest
+const config: Config = {
+    coverageProvider: 'v8',
+    testEnvironment: 'jsdom'
+    // Add more setup options before each test is run
+    // setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+}
+
+// createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async
+export default createJestConfig(config)

--- a/test/data-table-footer.test.tsx
+++ b/test/data-table-footer.test.tsx
@@ -1,21 +1,17 @@
-// @ts-nocheck
-
 // vendors
 import '@testing-library/jest-dom'
-import MuiTableFooter from '@mui/material/TableFooter'
-import { render } from '@testing-library/react'
+import { TablePagination as OriginalPaginationFromMui } from '@mui/material'
+import { render, screen } from '@testing-library/react'
 // locals
-import type { DataTableProps } from '../src'
-import { TEXT_LABELS } from '../src/statics'
+import type { DataTableOptions, DataTableProps } from '../src'
 import TableFooter from '../src/components/footer'
 
 /**
- * @todo FIX TYPE ERROR TO REMOVE `@ts-nocheck`
+ * @todo CONSOLIDATE TYPES
  */
 describe('<DataTableFooter />', function () {
     const options: DataTableProps['options'] = {
-        rowsPerPageOptions: [5, 10, 15],
-        textLabels: TEXT_LABELS
+        rowsPerPageOptions: [5, 10, 15]
     }
 
     const changeRowsPerPage = jest.fn()
@@ -36,10 +32,25 @@ describe('<DataTableFooter />', function () {
         expect(
             container.getElementsByClassName('datatable-delight--footer').length
         ).toBe(1)
+
+        /**
+         * prev and next button
+         */
+        expect(screen.getAllByRole('button').length).toBe(2)
+
+        /**
+         * Row per page select/dropdown
+         */
+        expect(screen.getAllByRole('combobox').length).toBe(1)
+
+        /**
+         * Row per page options ([5, 10, 15])
+         */
+        // expect(screen.getAllByRole('option').length).toBe(3)
     })
 
     it('should render a table footer with customFooter', () => {
-        const customOptions = {
+        const customOptions: DataTableOptions = {
             ...options,
             customFooter: (
                 rowCount,
@@ -50,13 +61,16 @@ describe('<DataTableFooter />', function () {
                 textLabels
             ) => {
                 return (
-                    <MuiTableFooter
-                        changePage={changePage}
-                        changeRowsPerPage={changeRowsPerPage}
+                    <OriginalPaginationFromMui
+                        count={rowCount}
+                        component="div"
+                        labelRowsPerPage={textLabels.pagination?.rowsPerPage}
+                        onPageChange={(_, page) => changePage(page)}
+                        onRowsPerPageChange={event =>
+                            changeRowsPerPage(event.target.value)
+                        }
                         page={page}
-                        rowCount={rowCount}
                         rowsPerPage={rowsPerPage}
-                        labelRowsPerPage={textLabels.rowsPerPage}
                     />
                 )
             }
@@ -73,7 +87,12 @@ describe('<DataTableFooter />', function () {
             />
         )
 
-        expect(container.getElementsByTagName('tfoot').length).toBe(1)
+        /**
+         * The `<OriginalPaginationFromMui />` className
+         */
+        expect(
+            container.getElementsByClassName('MuiTablePagination-root').length
+        ).toBe(1)
     })
 
     it('should not render a table footer', () => {


### PR DESCRIPTION
Eliminate `TEXT_LABELS` to align with recent changes and improve test coverage by updating Jest configuration to support Next.js.