### PR TITLE
Split dark theme provider into its own component file

### DIFF
--- a/docs/components/code-snippet.always-dark-theme-provider.tsx
+++ b/docs/components/code-snippet.always-dark-theme-provider.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import { createTheme, ThemeProvider } from '@mui/material'
+import type { ReactNode } from 'react'
+
+export function AlwaysDarkThemeProvider({ children }: { children: ReactNode }) {
+    return <ThemeProvider theme={theme}>{children}</ThemeProvider>
+}
+
+const theme = createTheme({
+    colorSchemes: {
+        dark: true
+    },
+    palette: {
+        mode: 'dark'
+    }
+})

--- a/docs/components/code-snippet.tsx
+++ b/docs/components/code-snippet.tsx
@@ -1,13 +1,12 @@
-'use client'
+import { Box, Paper } from '@mui/material'
+import { AlwaysDarkThemeProvider } from './code-snippet.always-dark-theme-provider'
 
-import { Box, createTheme, Paper, ThemeProvider } from '@mui/material'
+// prisms
 import prism from 'prismjs'
-
 import 'prismjs/components/prism-jsx'
 import 'prismjs/components/prism-bash'
 import 'prismjs/components/prism-typescript'
 import 'prismjs/components/prism-tsx'
-
 // @ts-expect-error IDK
 import 'prismjs/themes/prism-tomorrow.css'
 
@@ -25,7 +24,7 @@ export function CodeSnippet({
     )
 
     return (
-        <ThemeProvider theme={theme} noSsr>
+        <AlwaysDarkThemeProvider>
             <Paper elevation={4}>
                 <Box
                     component="pre"
@@ -43,15 +42,6 @@ export function CodeSnippet({
                     />
                 </Box>
             </Paper>
-        </ThemeProvider>
+        </AlwaysDarkThemeProvider>
     )
 }
-
-const theme = createTheme({
-    colorSchemes: {
-        dark: true
-    },
-    palette: {
-        mode: 'dark'
-    }
-})


### PR DESCRIPTION
Extract the dark theme provider into a separate file for better organization and reusability. Update the code snippet component to utilize the new provider.