### PR TITLE
Split download and print buttons into separate components

### DIFF
--- a/src/components/toolbar.download-button.tsx
+++ b/src/components/toolbar.download-button.tsx
@@ -1,0 +1,34 @@
+// materials
+import { IconButton, Tooltip } from '@mui/material'
+// locals
+import { useMainContext } from '../hooks/use-main-context'
+import type { DataTableOptions } from '../data-table.props.type/options'
+import { ICON_BUTTON_DEFAULT_SX } from './toolbar.icon-button-default-sx'
+
+export function ToolbarDownloadButton({
+    options,
+    onDownload
+}: {
+    options: DataTableOptions
+    onDownload: () => void
+}) {
+    const {
+        icons,
+        textLabels: { toolbar: toolbarTextLabels }
+    } = useMainContext()
+
+    return (
+        <Tooltip title={toolbarTextLabels.downloadCsv}>
+            <span>
+                <IconButton
+                    aria-label={toolbarTextLabels.downloadCsv}
+                    disabled={options.download === 'disabled'}
+                    onClick={onDownload}
+                    sx={ICON_BUTTON_DEFAULT_SX}
+                >
+                    <icons.DownloadIcon />
+                </IconButton>
+            </span>
+        </Tooltip>
+    )
+}

--- a/src/components/toolbar.icon-button-default-sx.ts
+++ b/src/components/toolbar.icon-button-default-sx.ts
@@ -1,0 +1,7 @@
+import type { IconButtonProps } from '@mui/material'
+
+export const ICON_BUTTON_DEFAULT_SX: IconButtonProps['sx'] = theme => ({
+    '&:hover': {
+        color: theme.palette.primary.main
+    }
+})

--- a/src/components/toolbar.print-button.tsx
+++ b/src/components/toolbar.print-button.tsx
@@ -1,0 +1,41 @@
+// vendors
+import { IReactToPrintProps, useReactToPrint } from 'react-to-print'
+// materials
+import { IconButton, Tooltip } from '@mui/material'
+// locals
+import { useMainContext } from '../hooks/use-main-context'
+import type { DataTableOptions } from '../data-table.props.type/options'
+import { ICON_BUTTON_DEFAULT_SX } from './toolbar.icon-button-default-sx'
+
+export function ToolbarPrintButton({
+    options,
+    printContent
+}: {
+    options: DataTableOptions
+    printContent: IReactToPrintProps['content']
+}) {
+    const {
+        icons,
+        textLabels: { toolbar: toolbarTextLabels }
+    } = useMainContext()
+
+    const handlePrint = useReactToPrint({
+        content: printContent
+    })
+
+    return (
+        <Tooltip title={toolbarTextLabels.print}>
+            <span>
+                <IconButton
+                    data-testid={toolbarTextLabels.print + '-iconButton'}
+                    aria-label={toolbarTextLabels.print}
+                    disabled={options.print === 'disabled'}
+                    onClick={handlePrint}
+                    sx={ICON_BUTTON_DEFAULT_SX}
+                >
+                    <icons.PrintIcon />
+                </IconButton>
+            </span>
+        </Tooltip>
+    )
+}

--- a/src/components/toolbar.tsx
+++ b/src/components/toolbar.tsx
@@ -1,7 +1,6 @@
 // vendors
 import { makeStyles } from 'tss-react/mui'
 import React from 'react'
-import ReactToPrint, { PrintContextConsumer } from 'react-to-print'
 // materials
 import {
     IconButton,
@@ -18,6 +17,8 @@ import { DataTableState } from '../data-table.props.type/state'
 import { useMainContext } from '../hooks/use-main-context'
 // internals
 import { ToolbarPopover } from './toolbar.popover'
+import { ToolbarPrintButton } from './toolbar.print-button'
+import { ToolbarDownloadButton } from './toolbar.download-button'
 
 const CLASS_ID = 'datatable-delight--toolbar'
 
@@ -84,8 +85,12 @@ class TableToolbarClass extends React.Component<TEMPORARY_CLASS_PROP_TYPE> {
         }
     }
 
+    /**
+     * @todo MOVE THIS TO <ToolbarDownloadButton />
+     */
     handleCSVDownload = () => {
         const { data, displayData, columns, options, columnOrder } = this.props
+
         let dataToDownload = [] //cloneDeep(data);
         let columnsToDownload = []
         let columnOrderCopy = Array.isArray(columnOrder)
@@ -171,7 +176,9 @@ class TableToolbarClass extends React.Component<TEMPORARY_CLASS_PROP_TYPE> {
         createCsvDownload(columnsToDownload, dataToDownload, options)
     }
 
-    setActiveIcon = iconName => {
+    setActiveIcon = (
+        iconName: 'search' | 'filter' | 'viewcolumns' | undefined
+    ) => {
         this.setState(
             prevState => ({
                 showSearch: this.isSearchShown(iconName),
@@ -286,18 +293,16 @@ class TableToolbarClass extends React.Component<TEMPORARY_CLASS_PROP_TYPE> {
         const TableFilterComponent =
             components.TableFilter ?? DataTableToolbarFilter
         const SearchIconComponent = icons.SearchIcon
-        const DownloadIconComponent = icons.DownloadIcon
-        const PrintIconComponent = icons.PrintIcon
         const ViewColumnIconComponent = icons.ViewColumnIcon
         const FilterIconComponent = icons.FilterIcon
 
-        const { search, downloadCsv, print, viewColumns, filterTable } =
+        const { search, viewColumns, filterTable } =
             this.props.context.textLabels.toolbar
         const { showSearch } = this.state
 
         const filterPopoverExit = () => {
             this.setState({ hideFilterPopover: false })
-            this.setActiveIcon()
+            this.setActiveIcon(undefined)
         }
 
         const closeFilterPopover = () => {
@@ -369,58 +374,23 @@ class TableToolbarClass extends React.Component<TEMPORARY_CLASS_PROP_TYPE> {
                     )}
 
                     {options.download && (
-                        <Tooltip title={downloadCsv}>
-                            <span>
-                                <IconButton
-                                    data-testid={
-                                        downloadCsv.replace(/\s/g, '') +
-                                        '-iconButton'
-                                    }
-                                    aria-label={downloadCsv}
-                                    classes={{ root: classes.icon }}
-                                    disabled={options.download === 'disabled'}
-                                    onClick={this.handleCSVDownload}
-                                >
-                                    <DownloadIconComponent />
-                                </IconButton>
-                            </span>
-                        </Tooltip>
+                        <ToolbarDownloadButton
+                            options={options}
+                            onDownload={this.handleCSVDownload}
+                        />
                     )}
 
                     {options.print && (
-                        <span>
-                            <ReactToPrint content={() => this.props.tableRef()}>
-                                <PrintContextConsumer>
-                                    {({ handlePrint }) => (
-                                        <span>
-                                            <Tooltip title={print}>
-                                                <IconButton
-                                                    data-testid={
-                                                        print + '-iconButton'
-                                                    }
-                                                    aria-label={print}
-                                                    disabled={
-                                                        options.print ===
-                                                        'disabled'
-                                                    }
-                                                    onClick={handlePrint}
-                                                    classes={{
-                                                        root: classes.icon
-                                                    }}
-                                                >
-                                                    <PrintIconComponent />
-                                                </IconButton>
-                                            </Tooltip>
-                                        </span>
-                                    )}
-                                </PrintContextConsumer>
-                            </ReactToPrint>
-                        </span>
+                        <ToolbarPrintButton
+                            options={options}
+                            // printContent={this.props.tableRef}
+                            printContent={() => <h1>helo</h1>}
+                        />
                     )}
 
                     {options.viewColumns && (
                         <ToolbarPopover
-                            refExit={() => this.setActiveIcon()}
+                            refExit={() => this.setActiveIcon(undefined)}
                             hide={options.viewColumns === 'disabled'}
                             trigger={
                                 <Tooltip
@@ -441,10 +411,9 @@ class TableToolbarClass extends React.Component<TEMPORARY_CLASS_PROP_TYPE> {
                                         disabled={
                                             options.viewColumns === 'disabled'
                                         }
-                                        onClick={this.setActiveIcon.bind(
-                                            null,
-                                            'viewcolumns'
-                                        )}
+                                        onClick={() =>
+                                            this.setActiveIcon('viewcolumns')
+                                        }
                                     >
                                         <ViewColumnIconComponent />
                                     </IconButton>
@@ -493,10 +462,9 @@ class TableToolbarClass extends React.Component<TEMPORARY_CLASS_PROP_TYPE> {
                                             disabled={
                                                 options.filter === 'disabled'
                                             }
-                                            onClick={this.setActiveIcon.bind(
-                                                null,
-                                                'filter'
-                                            )}
+                                            onClick={() =>
+                                                this.setActiveIcon('filter')
+                                            }
                                         >
                                             <FilterIconComponent />
                                         </IconButton>


### PR DESCRIPTION
Separate the download and print button functionalities into distinct components for better modularity and maintainability. This change enhances the toolbar's structure by organizing related functionalities into their own files.