### PR TITLE
Removes Next.js output export configuration

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,6 @@ import createMDX from '@next/mdx'
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
-    output: 'export',
     pageExtensions: ['md', 'mdx', 'ts', 'tsx'],
     reactCompiler: true,
     reactStrictMode: true


### PR DESCRIPTION
Removes the explicit `output: 'export'` configuration from Next.js. This change is typically made when opting for a traditional server-based deployment or a different static site generation approach that doesn't rely solely on the `next export` command.