### PR TITLE
Refactors filter state management and chip removal

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,5 +78,5 @@
         "test:watch": "vitest watch --silent=false"
     },
     "types": "./dist/types.d.ts",
-    "version": "2.0.1"
+    "version": "2.0.2"
 }

--- a/src/components/filtered-values-list.tsx
+++ b/src/components/filtered-values-list.tsx
@@ -4,6 +4,7 @@ import Box from '@mui/material/Box'
 import Chip, { type ChipProps } from '@mui/material/Chip'
 import ComponentClassName from '@src/enums/class-name'
 import type { FilterUpdateType } from '@src/types/filter-update'
+import { Activity } from 'react'
 // vendors
 import useDataTableContext from '../hooks/use-data-table-context'
 import type { FilterTypeType } from '../types/shared/filter-type-type'
@@ -19,7 +20,6 @@ export default function FilteredValuesList<T>({
     filterUpdate
 }: TableFilterListProps<T>): React.ReactNode {
     const { options, state } = useDataTableContext<T>()
-    const { serverSide } = options
 
     const columnNames = state.columns.map(column => ({
         filterType: column.filterType ?? options.filterType,
@@ -36,14 +36,14 @@ export default function FilteredValuesList<T>({
 
     function removeFilter<T>(
         index: number,
-        filterValue: string,
+        filterValueThatWillBeRemoved: string,
         columnName: string | undefined,
         filterType: FilterTypeType
     ) {
-        const removedFilter =
-            Array.isArray(filterValue) && filterValue.length === 0
-                ? state.filterList[index]
-                : filterValue
+        const newFilterValues =
+            state.filterList[index]?.filter(
+                filter => filter !== filterValueThatWillBeRemoved
+            ) ?? []
 
         const column = state.columns.find(column => column.name === columnName)
 
@@ -53,14 +53,14 @@ export default function FilteredValuesList<T>({
 
         filterUpdate(
             index,
-            filterValue,
+            newFilterValues,
             column,
             filterType,
             column.customFilterListOptions?.update,
             (filterList: DataTableState<T>['filterList']) => {
                 options.onFilterChipClose?.(
                     index,
-                    removedFilter ?? [],
+                    filterValueThatWillBeRemoved,
                     filterList
                 )
             }
@@ -117,9 +117,9 @@ export default function FilteredValuesList<T>({
         <Chip
             key={colIndex}
             label={filterListRenderers[index]?.(data)}
-            onDelete={() =>
+            onDelete={() => {
                 removeFilter(index, data, columnNames[index]?.name, 'chip')
-            }
+            }}
             sx={CHIP_SX}
             // itemKey={colIndex}
             // index={index}
@@ -174,18 +174,24 @@ export default function FilteredValuesList<T>({
         })
     }
 
+    const isHasFilter = state.filterList.some(filter =>
+        Array.isArray(filter) ? filter.length > 0 : !!filter
+    )
+
     return (
-        <Box
-            className={ComponentClassName.FILTERED_VALUES_LIST}
-            sx={{
-                display: 'flex',
-                flexWrap: 'wrap',
-                justifyContent: 'left',
-                margin: '8px 16px 8px 16px'
-            }}
-        >
-            {serverSide && getFilterList(state.filterList)}
-        </Box>
+        <Activity mode={isHasFilter ? 'visible' : 'hidden'}>
+            <Box
+                className={ComponentClassName.FILTERED_VALUES_LIST}
+                sx={{
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                    justifyContent: 'left',
+                    margin: '0px 16px 16px 16px'
+                }}
+            >
+                {getFilterList(state.filterList)}
+            </Box>
+        </Activity>
     )
 }
 

--- a/src/components/toolbar/components/data-filter-box/components/filter-inputs.tsx
+++ b/src/components/toolbar/components/data-filter-box/components/filter-inputs.tsx
@@ -31,10 +31,12 @@ import type { Primitive } from '@src/types/values/primitive'
  */
 export default function ToolbarDataFilterBoxFilters<T>({
     filterUpdate,
-    innerFilterList: filterList
+    innerFilterList: filterList,
+    setInnerFilterList
 }: {
     filterUpdate: FilterUpdateType<T>
     innerFilterList: string[][]
+    setInnerFilterList: React.Dispatch<React.SetStateAction<string[][]>>
 }): React.ReactElement {
     const { textLabels, options, state } = useDataTableContext<T>()
 
@@ -50,6 +52,14 @@ export default function ToolbarDataFilterBoxFilters<T>({
                     filterData={state.filterData}
                     filterList={filterList}
                     handleCheckboxChange={value => {
+                        setInnerFilterList(prev => {
+                            prev[index] = Array.isArray(value)
+                                ? value
+                                : [value as string]
+
+                            return [...prev]
+                        })
+
                         if (options.confirmFilters !== true) {
                             filterUpdate?.(
                                 index,
@@ -74,6 +84,14 @@ export default function ToolbarDataFilterBoxFilters<T>({
                     index={index}
                     key={column.name}
                     onSelectChange={event => {
+                        setInnerFilterList(prev => {
+                            prev[index] = Array.isArray(event.target.value)
+                                ? event.target.value
+                                : [event.target.value]
+
+                            return [...prev]
+                        })
+
                         if (options.confirmFilters !== true) {
                             filterUpdate?.(
                                 index,
@@ -95,6 +113,12 @@ export default function ToolbarDataFilterBoxFilters<T>({
                     index={index}
                     key={column.name}
                     onChange={event => {
+                        setInnerFilterList(prev => {
+                            prev[index] = [event.target.value]
+
+                            return [...prev]
+                        })
+
                         if (options.confirmFilters !== true) {
                             filterUpdate?.(
                                 index,
@@ -115,6 +139,19 @@ export default function ToolbarDataFilterBoxFilters<T>({
                     filterData={state.filterData}
                     filterList={filterList}
                     handleCustomChange={(value, index, column) => {
+                        const values =
+                            value === textLabels.filter.all
+                                ? []
+                                : Array.isArray(value)
+                                  ? value
+                                  : [value]
+
+                        setInnerFilterList(prev => {
+                            prev[index] = values
+
+                            return [...prev]
+                        })
+
                         if (options.confirmFilters !== true) {
                             filterUpdate?.(
                                 index,
@@ -138,15 +175,21 @@ export default function ToolbarDataFilterBoxFilters<T>({
                 index={index}
                 key={column.name}
                 onChange={event => {
-                    const value =
+                    const values =
                         event.target.value === textLabels.filter.all
                             ? []
                             : [event.target.value]
 
+                    setInnerFilterList(prev => {
+                        prev[index] = values
+
+                        return [...prev]
+                    })
+
                     if (options.confirmFilters !== true) {
                         filterUpdate?.(
                             index,
-                            value,
+                            values,
                             column,
                             FilterType.DROPDOWN
                         )

--- a/src/components/toolbar/components/data-filter-box/index.tsx
+++ b/src/components/toolbar/components/data-filter-box/index.tsx
@@ -128,6 +128,7 @@ export default function ToolbarDataFilterBox<T>({
             <ToolbarDataFilterBoxFilters
                 filterUpdate={filterUpdate}
                 innerFilterList={filterList}
+                setInnerFilterList={setFilterList}
             />
 
             {options.customFilterDialogFooter?.(filterList, () => {

--- a/src/functions/update-filter-by-type.ts
+++ b/src/functions/update-filter-by-type.ts
@@ -12,52 +12,51 @@ export function updateFilterByType(
         index: number
     ) => string[][]
 ) {
+    let newFilterList = JSON.parse(JSON.stringify(filterList))
+
     const filterIndexPosition: number =
-        filterList[index]?.indexOf(
+        newFilterList[index]?.indexOf(
             typeof value === 'string' ? value : (value[0] ?? '')
         ) ?? -1
 
     switch (type) {
         case 'checkbox':
             if (filterIndexPosition >= 0) {
-                filterList[index]?.splice(filterIndexPosition, 1)
+                newFilterList[index]?.splice(filterIndexPosition, 1)
             } else if (typeof value === 'string') {
-                filterList[index]?.push(value)
+                newFilterList[index]?.push(value)
             }
 
             break
 
         case 'chip':
-            if (filterIndexPosition >= 0) {
-                filterList[index]?.splice(filterIndexPosition, 1)
-            } else if (typeof value === 'string') {
-                filterList[index]?.push(value)
-            }
+            newFilterList[index] = value
+
             break
 
         case 'multiselect':
-            filterList[index] = typeof value === 'string' ? [] : value
+            newFilterList[index] = typeof value === 'string' ? [] : value
             break
 
         case 'dropdown':
-            filterList[index] = typeof value === 'string' ? [] : value
+            newFilterList[index] = typeof value === 'string' ? [] : value
             break
 
         case 'custom':
             if (customUpdate) {
-                filterList = customUpdate(
-                    filterList,
+                newFilterList = customUpdate(
+                    newFilterList,
                     filterIndexPosition,
                     index
                 )
             } else {
-                filterList[index] = typeof value === 'string' ? [] : value
+                newFilterList[index] = typeof value === 'string' ? [] : value
             }
             break
 
         default:
-            filterList[index] = typeof value === 'string' ? [value] : value
+            newFilterList[index] = typeof value === 'string' ? [value] : value
     }
 
-    return filterList
+    return newFilterList
 }

--- a/src/hooks/use-filter-update.ts
+++ b/src/hooks/use-filter-update.ts
@@ -3,6 +3,7 @@ import { updateFilterByType } from '@src/functions/update-filter-by-type'
 import useDataTableContext from '@src/hooks/use-data-table-context'
 import type { FilterUpdateType } from '@src/types/filter-update'
 import getDisplayData from '../functions/get-new-state-on-data-change/get-display-data'
+import type { DataTableState } from '../types/state'
 
 export function useFilterUpdate<T>(): FilterUpdateType<T> {
     const { onAction, options, state, updateCellValueRef } =
@@ -16,19 +17,17 @@ export function useFilterUpdate<T>(): FilterUpdateType<T> {
         customUpdate,
         next
     ) => {
-        const prevState = state
-
-        const newFilterList = updateFilterByType(
-            prevState.filterList,
-            index,
-            value,
-            type,
-            customUpdate
-        )
+        const prevState = JSON.parse(JSON.stringify(state)) as DataTableState<T>
 
         const newState = {
             ...prevState,
-            filterList: newFilterList,
+            filterList: updateFilterByType(
+                prevState.filterList,
+                index,
+                value,
+                type,
+                customUpdate
+            ),
             page: 0
         }
 
@@ -37,7 +36,7 @@ export function useFilterUpdate<T>(): FilterUpdateType<T> {
             : getDisplayData(
                   prevState.columns,
                   prevState.data,
-                  prevState.filterList,
+                  newState.filterList,
                   prevState.searchText,
                   newState,
                   options,

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -255,7 +255,7 @@ export interface DataTableOptions<Row = DefaultRow>
      */
     onFilterChipClose?: (
         index: number,
-        removedFilter: string | string[],
+        value: string,
         filterList: DataTableState<Row>['filterList']
     ) => void
 

--- a/src/types/props/column-definition/options.ts
+++ b/src/types/props/column-definition/options.ts
@@ -240,11 +240,13 @@ export interface ColumnDefinitionOptions<T> {
      *
      * Use 'custom' is you are supplying your own rendering via filterOptions.
      *
+     * `chip` is only for removing filters.
+     *
      * @default 'dropdown'
      *
      * @see  {@link FilterTypeType}
      */
-    filterType?: FilterTypeType
+    filterType?: Exclude<FilterTypeType, 'chip'>
 
     /**
      * Filter value list.


### PR DESCRIPTION
Ensures immutable updates for filter lists and data table state by performing deep copies before modifications.

Improves filter chip removal logic to precisely remove individual values from multi-select filters, rather than clearing the entire filter for a column. Updates the `onFilterChipClose` callback to provide the specific value removed.

Introduces local state management for filter inputs in the toolbar, allowing immediate UI feedback during user interaction, even when `confirmFilters` is enabled.

Conditionally renders the filter chip list, displaying it only when active filters are present, enhancing UI clarity. Clarifies `filterType` definitions, explicitly marking 'chip' as an action type for removal, not a column filter type.